### PR TITLE
Adjusting the method for highlighting multiple words

### DIFF
--- a/site/dbFunctions.php
+++ b/site/dbFunctions.php
@@ -543,10 +543,7 @@ function highlightSearch($tValue){
       $tValue = highlight($tWords, $tValue);
     }else {
       $atSearch = explode (' ', $tWords);
-      foreach ($atSearch as $tWordsWord) {
-        // $tValue = str_ireplace($tWordsWord, '<span class="highlightWord">' . $tWordsWord . '</span>', $tValue);
-        $tValue = highlight($tWordsWord, $tValue);
-      }
+      $tValue = highlightWords($atSearch, $tValue);
     }
   }
   return '<!-- highlightSearch ' . $tWords . ' -->' . $tValue;
@@ -562,6 +559,24 @@ function highlight($needle, $haystack){
          substr($haystack, $ind, $len) .'</span>' .
           highlight($needle, substr($haystack, $ind + $len));
   } else return $haystack;
+}
+
+// ============================================================================
+function highlightWords(array $words, string $haystack): string {
+// ============================================================================
+    $words = array_unique(array_map(fn($input) => strtolower(trim($input)), $words));
+    $words = array_filter($words);
+
+    if (empty($words)) {
+        return $haystack;
+    }
+
+    $pattern = '/\b(' . implode('|', array_map('preg_quote', $words)) . ')\b/i';
+    return preg_replace_callback(
+        $pattern,
+        fn($match) => "<span class=\"highlightWord\">{$match[0]}</span>",
+        $haystack
+    );
 }
 
 // ============================================================================


### PR DESCRIPTION
This is a proposed fix for https://github.com/nielsencs/BibleStudyMan/issues/168

In this issue, if you search for the phrase "You are the light of the world", some HTML fragments appear on the page:

| <img src="https://github.com/user-attachments/assets/2ff773d3-3bb6-4aa4-b183-4e6a7003e53c" width="300"> | <img src="https://github.com/user-attachments/assets/12e02198-4d11-4f4d-a9f6-f6ed5c1b64f5" width="300"> |
| --- | --- |
| **Before:** HTML fragments appear on the page | **After:** The matching words are highlighted as expected |

The reason why this was happening is that the previous highlight mechanism was performing a search-and-replace against each word, but making the replacements against the input string with HTML tags being added on every iteration. Since the HTML tags include the class name "highlightWord", the search including the phrase "light" would interfere with previous highlights and HTML syntax, causing the problem

The solution here was to introduce a new mechanism called `highlightWords()` which will perform a regex-based find-and-replace using [PHP's `preg_replace_callback()`](https://www.php.net/manual/en/function.preg-replace-callback.php). This performs the HTML wrapping for all word matches at once, so replaced syntax isn't at risk of being replaced itself