### PR TITLE
Fix: Remove HTML tags from search results

### DIFF
--- a/site/dbFunctions.php
+++ b/site/dbFunctions.php
@@ -548,6 +548,8 @@ function highlightSearch($text): string {
         return $text;
     }
 
+    $text = strip_tags($text);
+
     if ($bExact) {
         // Exact phrase match
         $pattern = '/\b(' . preg_quote($tWords) . ')\b/i';


### PR DESCRIPTION
The search results were including HTML tags, such as `<span class="highlightOW">`, which were not part of the text and were displayed to the user.

This was caused by the `highlightSearch` function applying search highlighting to text that already contained HTML tags from the `processStrongs` function.

The fix is to strip all HTML tags from the text within the `highlightSearch` function before the search highlighting is applied. This ensures that only the plain text is searched and highlighted, and no unwanted HTML tags are displayed in the search results.

fixes #67